### PR TITLE
Avoid scientific nonation number

### DIFF
--- a/src/components/header/Header.js
+++ b/src/components/header/Header.js
@@ -7,7 +7,9 @@ const Header = () => {
    return (
       <div className="my_header">
          <div className="logo">
-            <span><a href="https://github.com/nucypher/stakeit.space" target="_blank">GitHub</a></span>
+            <span>
+               <a href="https://github.com/nucypher/stakeit.space" target="_blank" rel="noopener noreferrer">GitHub</a>
+            </span>
          </div>
          <Nav />
          <div className="my_address">

--- a/src/components/manage/manage-bottom/action-history/action-history.js
+++ b/src/components/manage/manage-bottom/action-history/action-history.js
@@ -119,7 +119,7 @@ const ActionHistory = ({ loading, actionHistoryList }) => {
             <div>Set worker</div>
             <div>Worker address: {item.returnValues.worker}</div>
           </>
-        ) 
+        )
       case "Deposited":
         return (
           <>
@@ -153,7 +153,7 @@ const ActionHistory = ({ loading, actionHistoryList }) => {
             <div className="event_column">{pickEventTitle(item)}</div>
             <span>{item.blockNumber}</span>
             <span>
-              <a className="txn_hash_link" href={item.link} target="_blank">
+              <a className="txn_hash_link" href={item.link} target="_blank" rel="noopener noreferrer">
                 {item.transactionHash.slice(0, 15)}...
               </a>
             </span>

--- a/src/services/web3-service.js
+++ b/src/services/web3-service.js
@@ -54,10 +54,10 @@ export default class ServiceWeb3 {
       }
       // Get users locked tokens
       const lockedStakerNits = await Escrow.methods.getLockedTokens(account, 0).call();
-      const lockedStakerNu = lockedStakerNits / 10 ** 18;
+      const lockedStakerNu = web3.utils.fromWei(lockedStakerNits, 'ether');
       // Calculate Stakers unlocked NU
-      const stakerUnlockedNits = StakerInfo.value - lockedStakerNits;
-      const stakerNuUnlocked = web3.utils.fromWei(String(stakerUnlockedNits), 'ether');
+      const stakerUnlockedNits = web3.utils.toBN(StakerInfo.value).sub(web3.utils.toBN(lockedStakerNits));
+      const stakerNuUnlocked = web3.utils.fromWei(stakerUnlockedNits, 'ether');
 
       const isReStakeLockedBool = await Escrow.methods.isReStakeLocked(account).call();
       const isRestakeLocked = isReStakeLockedBool ? 'Locked' : 'Unlocked';
@@ -171,7 +171,7 @@ export default class ServiceWeb3 {
       const cancellationTimeDuration = cancellationEndDate - startBidDate;
       const objD = this._convertMS(cancellationTimeDuration * 1000);
       const cancellationTimeDurationHuman = `${objD.day} D, ${objD.hour} H, ${objD.minute} M`;
-      
+
 
       // Calculate Cancellation Window Time Remaining
       const remainingCancelationTime = cancellationEndDate * 1000 - currentDateUnix;
@@ -233,7 +233,7 @@ export default class ServiceWeb3 {
       const completedWork = (await Escrow.methods.getCompletedWork(account).call()) - workInfo[1];
       // const completedWork = blabla - refundedWork;
       // Setters
-      
+
       const makeBid = async value => {
         await Worklock.methods.bid().send({
           from: accounts[0],


### PR DESCRIPTION
Use `web3.utils.toBN` for big number calculation. Big number calculation result may be a js number in scientific notation, which results in error throwing in `web3.uitls.fromWei`. e.g

```
> "10000000000000000000000000" - "0"
< 1e+25
```

Pass 1e+25 to `web3.utils.fromWei`, we get an error says unable to convert to BigNumber.